### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ LocalizableJs also ships as a React component, with attached listeners for langu
 		
 			return (
 				<div>
-					<LocalizableElement translationKey={"WelcomeMessage"} parameters={params} />
+					<LocalizableElement translationKey={'WelcomeMessage'} parameters={params} />
 				</div>
 			);
 			


### PR DESCRIPTION
Double quotes around the "translationKey" attribute was break for me.
